### PR TITLE
Fixed writing files to disk synchronously

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,11 +126,11 @@ client.saveScreenshotToImage = async function(imagePath, params) {
             output: 'image',
             token: client.token,
         }, {
-            responseType: 'arraybuffer'
+            responseType: 'stream'
         });
 
-        fs.writeFileSync(imagePath, response.data, 'binary');
-
+        const dest = fs.createWriteStream(imagePath);
+        response.data.pipe(dest)
     } catch(error) {
         throw formatError(error);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screenshotapi.net",
-  "version": "1.0.4",
+  "version": "1.1.4",
   "description": "SDK for screenshotapi.net",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Using streams when saving images to disk is more efficient, especially when you are making multiple API calls.